### PR TITLE
refactor: use pydantic validation

### DIFF
--- a/models.py
+++ b/models.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timedelta
+from enum import Enum
 from string import Template
 from typing import Optional
 
 from lnbits.db import FilterModel
 from lnbits.helpers import is_valid_email_address
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, validator
 
 
 class Webhook(BaseModel):
@@ -42,39 +43,32 @@ class AuctionRoomConfig(BaseModel):
     transfer_webhook: Webhook = Webhook()
 
 
+class AuctionTypes(str, Enum):
+    auction = "auction"
+    fixed_price = "fixed_price"
+
+
 class CreateAuctionRoomData(BaseModel):
     wallet_id: str
     fee_wallet_id: Optional[str] = None
     currency: str
     name: str
     description: str
-    type: str = "auction"  # [auction, fixed_price]
-    room_percentage: float = 10
-    min_bid_up_percentage: float = 5
+    auction_type: AuctionTypes = AuctionTypes.auction
+    room_percentage: float = Field(default=10, ge=0, le=100)
+    min_bid_up_percentage: float = Field(default=5, ge=0, le=100)
     is_open_room: bool = False
-
-    def validate_data(self):
-        if self.type not in ["auction", "fixed_price"]:
-            raise ValueError("Auction Room type must be 'auction' or 'fixed_price'.")
-        if self.room_percentage <= 0:
-            raise ValueError("Auction Room percentage must be positive.")
-
-        if self.type == "fixed_price":
-            self.min_bid_up_percentage = 0
-        else:
-            if self.min_bid_up_percentage <= 0:
-                raise ValueError("Auction Room bid up must be positive.")
 
 
 class EditAuctionRoomData(CreateAuctionRoomData):
     id: str
     extra: AuctionRoomConfig
 
-    def validate_data(self):
-        super().validate_data()
+    @validator("extra")
+    def validate_extra_data(self):
         if self.extra.duration.to_timedelta().total_seconds() <= 0:
             raise ValueError("Auction Room duration must be positive.")
-        if self.type == "fixed_price":
+        if self.auction_type == AuctionTypes.fixed_price:
             self.extra.duration.days = 365
 
 
@@ -83,7 +77,7 @@ class PublicAuctionRoom(BaseModel):
     name: str
     description: str
     currency: str
-    type: str = "auction"  # [auction, fixed_price]
+    auction_type: AuctionTypes = AuctionTypes.auction
     duration_seconds: int = Field(default=0, no_database=True)
 
     min_bid_up_percentage: float = 5
@@ -91,11 +85,11 @@ class PublicAuctionRoom(BaseModel):
 
     @property
     def is_auction(self):
-        return self.type == "auction"
+        return self.auction_type == AuctionTypes.auction
 
     @property
     def is_fixed_price(self):
-        return self.type == "fixed_price"
+        return self.auction_type == AuctionTypes.fixed_price
 
 
 class AuctionRoom(PublicAuctionRoom):
@@ -115,10 +109,10 @@ class AuctionRoom(PublicAuctionRoom):
 
 class CreateAuctionItem(BaseModel):
     name: str
+    transfer_code: str
+    ask_price: float = Field(default=0, ge=0)
     description: Optional[str] = None
     ln_address: Optional[str] = None
-    ask_price: float = 0
-    transfer_code: str
 
 
 class PublicAuctionItem(BaseModel):
@@ -127,7 +121,7 @@ class PublicAuctionItem(BaseModel):
     name: str
     active: bool = True
     description: Optional[str] = None
-    ask_price: float = 0
+    ask_price: float = Field(default=0, ge=0)
     current_price: float = 0
     created_at: datetime
     expires_at: datetime
@@ -180,14 +174,11 @@ class AuctionItemFilters(FilterModel):
 
 class BidRequest(BaseModel):
     memo: str
+    amount: float = Field(default=0, ge=0)
     ln_address: str | None = None
-    amount: float
 
-    def validate_data(self):
-        if self.amount <= 0:
-            raise ValueError("Bid amount must be positive.")
-        if not self.memo.strip():
-            raise ValueError("Memo is required.")
+    @validator("ln_address")
+    def validate_ln_address(self):
         if self.ln_address and not is_valid_email_address(self.ln_address):
             raise ValueError("Lightning Address is not valid.")
 

--- a/views.py
+++ b/views.py
@@ -92,7 +92,7 @@ async def bids_list(
             "request": request,
             "is_user_authenticated": user_id is not None,
             "is_user_room_owner": user_id == auction_room.user_id,
-            "is_auction_type": auction_room.type == "auction",
+            "is_auction_type": auction_room.is_auction,
             "auction_item": PublicAuctionItem(**auction_item.dict()).json(),
         },
     )

--- a/views_api.py
+++ b/views_api.py
@@ -82,7 +82,6 @@ async def api_get_auction_room(
 async def api_create_auction_room(
     data: CreateAuctionRoomData, user: User = Depends(check_user_exists)
 ):
-    data.validate_data()
     return await create_auction_room(user_id=user.id, data=data)
 
 
@@ -90,13 +89,12 @@ async def api_create_auction_room(
 async def api_update_auction_room(
     data: EditAuctionRoomData, user: User = Depends(check_user_exists)
 ) -> AuctionRoom:
-    data.validate_data()
     auction_room = await get_auction_room(data.id)
     if not auction_room:
         raise HTTPException(HTTPStatus.NOT_FOUND, "Auction Room not found.")
     if auction_room.user_id != user.id:
         raise HTTPException(HTTPStatus.FORBIDDEN, "Not authorized to edit this room.")
-    if auction_room.type != data.type:
+    if auction_room.auction_type != data.auction_type:
         raise HTTPException(HTTPStatus.BAD_REQUEST, "Cannot change auction room")
     for k, v in data.dict().items():
         setattr(auction_room, k, v)
@@ -215,7 +213,6 @@ async def api_place_bid(
     data: BidRequest,
     user_id: str = Depends(check_user_id),
 ) -> Bid:
-    data.validate_data()
     auction_item = await get_auction_item(auction_item_id)
     if not auction_item:
         raise HTTPException(HTTPStatus.NOT_FOUND, "Auction Item not found.")


### PR DESCRIPTION
instead of manual one

- changed property `type` to `auction_type` because type is a reserved word and could lead to some issues down the line
- AuctionTypes enum